### PR TITLE
Wu update includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ With lint-staged:
 
 ## How it works
 
-For the most part, it just forwards all arguments to `tsc` with one exception: the specified files will not be forwarded — instead, they will be put at the `files` property of a temporary config that will be generated next to your original `tsconfig.json`. Other than that, just read `tsc --help`.
+For the most part, it just forwards all arguments to `tsc` with one exception: the specified files will not be forwarded — instead, they will be put at the ~~`files`~~ `include` property of a temporary config that will be generated next to your original `tsconfig.json`. Other than that, just read `tsc --help`.
+
+Details on custom update in this forked version - the specified files will be put in the `include` property of the temporary `tsconfig` file. This prevents the `files` property in our default `tsconfig` from being overridden. 
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,11 +35,9 @@ const tmpTsconfig = {
     ...tsconfig.compilerOptions,
     skipLibCheck: true,
   },
-  // files,
   include: files,
 }
 fs.writeFileSync(tmpTsconfigPath, JSON.stringify(tmpTsconfig, null, 2))
-console.log('testing', tmpTsconfig)
 
 // Type-check our files
 const { status } = spawnSync(

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,10 +35,11 @@ const tmpTsconfig = {
     ...tsconfig.compilerOptions,
     skipLibCheck: true,
   },
-  files,
-  include: [],
+  // files,
+  include: files,
 }
 fs.writeFileSync(tmpTsconfigPath, JSON.stringify(tmpTsconfig, null, 2))
+console.log('testing', tmpTsconfig)
 
 // Type-check our files
 const { status } = spawnSync(


### PR DESCRIPTION
`tsc` is the normal typechecking command we run for our projects. Unfortunately, it has a limitation that you can't typecheck specific files while using your custom `tsconfig.json` file. You either can typecheck a whole project using your `tsconfig.json` file, or typecheck specific files with no `tsconfig.json` specified. This npm package, [tsc-files](https://github.com/gustavopch/tsc-files), solves this problem for us by typechecking specified files with our specified `tsconfig`.

`tsc-files` creates a custom `tsconfig` (`const tmpTsconfig` here) that extends our current `tsconfig`. The update I'm making here is passing the files we want to typecheck in the `include` property of the extended `tsconfig` instead of in the `files` property. This is because in our current `tsconfig` we have the following:
```
  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.tsx", "src/**/*.jsx"],
  "exclude": ["node_modules", "*.json"],
  "files": ["react-table-config.d.ts", "custom.d.ts", "window.d.ts"]
```
If we pass in `files: [customfile1.tsx, customfile2.ts]`, then our ` "files": ["react-table-config.d.ts", "custom.d.ts", "window.d.ts"]` will be overridden which leads to typescript errors that we have setup our `*.d.ts` files to handle. I've made this update so that we pass in `include: [customfile1.tsx, customfile2.ts]` so that only these files are typechecked properly. 